### PR TITLE
Fix profile URLs

### DIFF
--- a/src/github-social-provider.js
+++ b/src/github-social-provider.js
@@ -130,7 +130,7 @@ GithubSocialProvider.prototype.login = function(loginOpts) {
                   userId: user.login,
                   name: user.name,
                   lastUpdated: Date.now(),
-                  url: user.url,
+                  url: user.html_url,
                   imageData: user.avatar_url
                 };
                 this.addUserProfile_(profile);
@@ -356,7 +356,7 @@ GithubSocialProvider.prototype.getUserProfile_ = function(userId) {
           userId: user.login,
           name: user.nameGist,
           lastUpdated: Date.now(),
-          url: user.url,
+          url: user.html_url,
           imageData: user.avatar_url,
         };
         fulfill(this.addUserProfile_(profile));


### PR DESCRIPTION
Fix profile URLs: https://github.com/uProxy/uproxy/issues/1944.  This changes URLs from things like https://api.github.com/users/EvaUproxy to https://github.com/EvaUproxy.

Tested in Chrome
