### PR TITLE
Force a single redirect URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-social-github",
   "description": "GitHub Social Provider for freedomjs",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/freedomjs/freedom-social-github.git"

--- a/src/github-social-provider.js
+++ b/src/github-social-provider.js
@@ -89,12 +89,10 @@ GithubSocialProvider.prototype.login = function(loginOpts) {
   return new Promise(function(fulfillLogin, rejectLogin) {
     // Note that each Github app (identified by its client_id) only accepts a
     // single redirect URL.  The acceptable URL for the current client_id must
-    // be the first entry in this list.
+    // be the only entry in this list, because otherwise the oauth provider is
+    // free to select any of them.
     var OAUTH_REDIRECT_URLS = [
-      "https://fmdppkkepalnkeommjadgbhiohihdhii.chromiumapp.org/",
-      "https://www.uproxy.org/oauth-redirect-uri",
-      "http://freedomjs.org/",
-      "http://localhost:8080/"
+      "https://fmdppkkepalnkeommjadgbhiohihdhii.chromiumapp.org/"
     ];
     var OAUTH_CLIENT_ID = '6b4c318b61fa1bd2ec82';
     var OAUTH_CLIENT_SECRET = '121fd189832494a00f7f79f39d3ef4883ba0fc36';


### PR DESCRIPTION
uProxy's Chrome Oauth provider ignores ordering of URIs, and prefers uproxy.org redirects over other options.  Force it to use only the option that will actually work.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/freedomjs/freedom-social-github/14)

<!-- Reviewable:end -->
